### PR TITLE
XOR_DEPENDS' JIT via pre-comupted code segment pasting

### DIFF
--- a/gf-complete/gf_w16.c
+++ b/gf-complete/gf_w16.c
@@ -648,6 +648,8 @@ int gf_w16_xor_init(gf_t *gf)
   
   /* alloc JIT region */
   jit->code = jit_alloc(jit->len = 4096); /* 4KB should be enough for everyone */
+  /* pre-calc JIT lookup tables */
+  gf_w16_xor_create_jit_lut();
   
   /* if JIT allocation was successful (no W^X issue), use slightly faster JIT version, otherwise fall back to static code version */
   gf->multiply_region.w32 = jit->code ? gf_w16_xor_lazy_sse_jit_altmap_multiply_region : gf_w16_xor_lazy_sse_altmap_multiply_region;

--- a/gf-complete/gf_w16_additions.c
+++ b/gf-complete/gf_w16_additions.c
@@ -1459,7 +1459,7 @@ static void gf_w16_xor_lazy_sse_jit_altmap_multiply_region(gf_t *gf, void *src, 
 #endif
             #undef PROC_BITPAIR
             
-            if(!movC) jit->ptr[posC] = 0x6F; // PXOR -> MOVDQA
+            jit->ptr[posC + movC] = 0x6F; // PXOR -> MOVDQA
             _C_XORPS_R(0, 2, movC==0);
             _C_PXOR_R(1, 2, movC==0); /*penalty?*/
           }
@@ -1505,8 +1505,8 @@ static void gf_w16_xor_lazy_sse_jit_altmap_multiply_region(gf_t *gf, void *src, 
             PROC_BITPAIR(7, reg, mask, 0);
 #endif
             #undef PROC_BITPAIR
-            if(!mov1) jit->ptr[pos1] = 0x28; // XORPS -> MOVAPS
-            if(!mov2) jit->ptr[pos2] = 0x6F; // PXOR -> MOVDQA
+            jit->ptr[pos1 + mov1] = 0x28; // XORPS -> MOVAPS
+            jit->ptr[pos2 + mov2] = 0x6F; // PXOR -> MOVDQA
           } else {
             #define PROC_BITPAIR(n, bits, inf, m, r64) \
               jit->ptr += xor_jit_bitpair3_noxor(jit->ptr, xor_jit_bitpair3(jit->ptr, (m) & ((2<<bits)-2), xor_jit_clut_code ##n, xor_jit_clut_info_ ##inf, &posC, &movC, r64), &pos1, &mov1, &pos2, &mov2, r64); \
@@ -1528,8 +1528,8 @@ static void gf_w16_xor_lazy_sse_jit_altmap_multiply_region(gf_t *gf, void *src, 
 #endif
             #undef PROC_BITPAIR
           
-            if(!mov1) jit->ptr[pos1] = 0x28; // XORPS -> MOVAPS
-            if(!mov2) jit->ptr[pos2] = 0x6F; // PXOR -> MOVDQA
+            jit->ptr[pos1 + mov1] = 0x28; // XORPS -> MOVAPS
+            jit->ptr[pos2 + mov2] = 0x6F; // PXOR -> MOVDQA
             if(!movC) {
               jit->ptr[posC] = 0x6F; // PXOR -> MOVDQA
               if(mov1) { /* no additional XORs were made? */

--- a/gf-complete/gf_w16_additions.c
+++ b/gf-complete/gf_w16_additions.c
@@ -365,7 +365,7 @@ static void gf_w16_xor_lazy_sse_altmap_multiply_region(gf_t *gf, void *src, void
   FAST_U32 counts[16];
   uintptr_t deptable[16][16];
   __m128i depmask1, depmask2, polymask1, polymask2, addvals1, addvals2;
-  uint16_t tmp_depmask[16];
+  ALIGN(16, uint16_t tmp_depmask[16]);
   gf_region_data rd;
   gf_internal_t *h;
   __m128i *dW, *topW;
@@ -418,8 +418,8 @@ static void gf_w16_xor_lazy_sse_altmap_multiply_region(gf_t *gf, void *src, void
   }
   
   /* generate needed tables */
-  _mm_storeu_si128((__m128i*)(tmp_depmask), depmask1);
-  _mm_storeu_si128((__m128i*)(tmp_depmask + 8), depmask2);
+  _mm_store_si128((__m128i*)(tmp_depmask), depmask1);
+  _mm_store_si128((__m128i*)(tmp_depmask + 8), depmask2);
   for(bit=0; bit<16; bit++) {
     FAST_U32 cnt = 0;
     for(i=0; i<16; i++) {
@@ -934,8 +934,8 @@ static void gf_w16_xor_lazy_sse_jit_altmap_multiply_region(gf_t *gf, void *src, 
   FAST_U32 i, bit;
   long inBit;
   __m128i depmask1, depmask2, polymask1, polymask2, addvals1, addvals2;
-  uint16_t tmp_depmask[16];
-  uint32_t lumask[8];
+  ALIGN(16, uint16_t tmp_depmask[16]);
+  ALIGN(16, uint32_t lumask[8]);
   gf_region_data rd;
   gf_internal_t *h;
   jit_t* jit;
@@ -1036,7 +1036,7 @@ static void gf_w16_xor_lazy_sse_jit_altmap_multiply_region(gf_t *gf, void *src, 
       tmp2 = EXPAND_ROUND(tmp2, 2, 0x3333);
       tmp1 = EXPAND_ROUND(tmp1, 1, 0x5555);
       tmp2 = EXPAND_ROUND(tmp2, 1, 0x5555);
-      _mm_storeu_si128((__m128i*)(lumask), _mm_or_si128(tmp1, _mm_slli_epi16(tmp2, 1)));
+      _mm_store_si128((__m128i*)(lumask), _mm_or_si128(tmp1, _mm_slli_epi16(tmp2, 1)));
       
       tmp1 = _mm_unpackhi_epi8(tmp3l, tmp3h);
       tmp2 = _mm_unpackhi_epi8(tmp4l, tmp4h);
@@ -1044,7 +1044,7 @@ static void gf_w16_xor_lazy_sse_jit_altmap_multiply_region(gf_t *gf, void *src, 
       tmp2 = EXPAND_ROUND(tmp2, 2, 0x3333);
       tmp1 = EXPAND_ROUND(tmp1, 1, 0x5555);
       tmp2 = EXPAND_ROUND(tmp2, 1, 0x5555);
-      _mm_storeu_si128((__m128i*)(lumask + 4), _mm_or_si128(tmp1, _mm_slli_epi16(tmp2, 1)));
+      _mm_store_si128((__m128i*)(lumask + 4), _mm_or_si128(tmp1, _mm_slli_epi16(tmp2, 1)));
       
       #undef EXPAND_ROUND
       
@@ -1068,8 +1068,8 @@ static void gf_w16_xor_lazy_sse_jit_altmap_multiply_region(gf_t *gf, void *src, 
       for(i=0; i<8; i++)
         common_depmask[i] = 0;
       */
-      _mm_storeu_si128((__m128i*)(tmp_depmask), depmask1);
-      _mm_storeu_si128((__m128i*)(tmp_depmask + 8), depmask2);
+      _mm_store_si128((__m128i*)(tmp_depmask), depmask1);
+      _mm_store_si128((__m128i*)(tmp_depmask + 8), depmask2);
     }
     
     

--- a/gf-complete/gf_w16_split.c
+++ b/gf-complete/gf_w16_split.c
@@ -1,10 +1,4 @@
 
-#ifdef _MSC_VER
-#define ALIGN(_a, v) __declspec(align(_a)) v
-#else
-#define ALIGN(_a, v) v __attribute__((aligned(_a)))
-#endif
-
 
 /* src can be the same as dest */
 static void _FN(gf_w16_split_start)(void* src, int bytes, void* dest) {


### PR DESCRIPTION
Attempt to build JIT code via lookup tables of pre-assembled code bits, rather than assembling it up bit-by-bit. This should speed up JIT performance of the XOR_DEPENDS algorithm, one of its major weaknesses.

This is done firstly by interleaving dependency bits, pairwise. From each interleaved pair, mask off a portion of bits (up to 6, i.e. 3 inputs from the pair) and use this to lookup into a pre-computed code table, as well as a corresponding mask for correcting encoded registers / memory offsets.  
With this method, the 32 bits from a pair can be JIT'd in 6 lots of operations, instead of the previous 3x16 = 48 instruction writes.

Initial impressions are that it gives a very modest gain (~10-20% on Haswell) in small block size (4KB) performance. Still needs further tuning, but I don't expect gains to be much.

It doesn't handle the case of eliminating the redundant XOR when the common queue isn't needed. It may never get handled as doing so likely reduces performance (since only 4 bits can be processed at a time, rather than 6), and I expect gains from better JIT'd code to be very minor (at best, removes one MOVDQA instruction from the loop).