### PR TITLE
Set the md5mb-scalar alignment size to the machine pointer size

### DIFF
--- a/hasher/md5mb-scalar.h
+++ b/hasher/md5mb-scalar.h
@@ -2,7 +2,7 @@
 
 #define md5mb_regions_scalar 1
 #define md5mb_max_regions_scalar 1
-#define md5mb_alignment_scalar 4
+#define md5mb_alignment_scalar sizeof(void *)
 
 
 #define _FN(f) f##_scalar


### PR DESCRIPTION
This fixes an issue on macOS ARM64, where calls to [`aligned_alloc(4, ...)`](https://github.com/animetosho/ParPar/blob/458ed62ce509fe1392830de60c8c0a7f1e14e9cf/hasher/hasher_md5mb_base.h#L23) would fail and return a null pointer because their implementation requires the alignment to be [`>= sizeof(void *)`](https://github.com/Apple-FOSS-Mirror/Libc/blob/2ca2ae74647714acfc18674c3114b1a5d3325d7d/gen/malloc.c#L781) (8).

✅ `test/hasher` passed on a macOS M1 and on a x86_64 Linux.